### PR TITLE
Attempting to add deepscan runs

### DIFF
--- a/.github/workflows/deepscan.yml
+++ b/.github/workflows/deepscan.yml
@@ -1,0 +1,28 @@
+name: DeepScan Static Analysis
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  deepscan:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '22.8.0' 
+
+      - name: Install Dependencies
+        run: npm install
+
+      - name: Run DeepScan
+        uses: deepscanio/github-action@v1
+        with:
+          api_key: ${{ secrets.DEEPSCAN_API_KEY }}

--- a/.github/workflows/deepscan.yml
+++ b/.github/workflows/deepscan.yml
@@ -23,6 +23,6 @@ jobs:
         run: npm install
 
       - name: Run DeepScan
-        uses: deepscanio/github-action@v1
+        uses: DeepScanOSS/github-action@v1
         with:
           api_key: ${{ secrets.DEEPSCAN_API_KEY }}

--- a/.github/workflows/deepscan.yml
+++ b/.github/workflows/deepscan.yml
@@ -2,9 +2,9 @@ name: DeepScan Static Analysis
 
 on:
   push:
-    branches: [ main ]
+    branches: [ "**" ]
   pull_request:
-    branches: [ main ]
+    branches: [ "**" ]
 
 jobs:
   deepscan:


### PR DESCRIPTION
Adding DeepScan within the workflow for the final deliverable. This will ensure that DeepScan is run on all pushes and pulls on the main (f24) branch as part of our CI/CD process.